### PR TITLE
Removed RequiredModules from xPhpProvision, fixes PowerShell/xPhp#7.

### DIFF
--- a/.MetaTestOptIn.json
+++ b/.MetaTestOptIn.json
@@ -1,0 +1,4 @@
+[
+    "Common Tests - Validate Markdown Files",
+    "Common Tests - Validate Example Files"
+]

--- a/DscResources/xPhpProvision/xPhpProvision.Schema.psm1
+++ b/DscResources/xPhpProvision/xPhpProvision.Schema.psm1
@@ -1,11 +1,13 @@
 # Composite configuration to install the IIS pre-requisites for php
 Configuration IisPreReqs_php
 {
-    param (
+    param
+    (
         [Parameter(Mandatory = $true)]
         [Validateset("Present","Absent")]
-        [String] $Ensure
-    )    
+        [System.String]
+        $Ensure
+    )
 
     foreach ($feature in @("Web-Server", "Web-Mgmt-Tools", "Web-Default-Doc", `
             "Web-Dir-Browsing", "Web-Http-Errors", "Web-Static-Content", `
@@ -23,25 +25,32 @@ Configuration IisPreReqs_php
 # Composite configuration to install PHP on IIS
 Configuration xPhpProvision
 {
-    param (
+    param
+    (
         [Parameter(Mandatory = $true)]
-        [switch] $InstallMySqlExt,
+        [Switch]
+        $InstallMySqlExt,
 
-        [String] $PackageFolder = 'c:\package',
-
-        [Parameter(Mandatory = $true)]
-        [String] $DownloadUri,
-
-        [String] $Vc2012RedistDownloadUri = 'http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe',
-
-        [String] $DestinationPath = 'C:\php',
+        [System.String]
+        $PackageFolder = 'c:\package',
 
         [Parameter(Mandatory = $true)]
-        [String] $ConfigurationPath
+        [System.String]
+        $DownloadUri,
+
+        [System.String]
+        $Vc2012RedistDownloadUri = 'https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe',
+
+        [System.String]
+        $DestinationPath = 'C:\php',
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $ConfigurationPath
     )
-    
+
     Import-DscResource -ModuleName xWebAdministration
-    Import-DscResource -ModuleName xPsDesiredStateConfiguration 
+    Import-DscResource -ModuleName xPsDesiredStateConfiguration
 
     # Make sure the IIS Prerequisites for PHP are present
     IisPreReqs_php Iis
@@ -53,12 +62,12 @@ Configuration xPhpProvision
         # DependsOn = "[File]PackagesFolder"
     }
 
-    # Download and install Visual C Redist2012 from chocolatey.org
+    # Download and install Visual C++ Redist 2015 from microsoft.com
     Package vcRedist
     {
         Path = $Vc2012RedistDownloadUri
-        ProductId = "{CF2BEA3C-26EA-32F8-AA9B-331F7E34BA97}"
-        Name = "Microsoft Visual C++ 2012 x64 Minimum Runtime - 11.0.61030"
+        ProductId = "{0D3E9E15-DE7A-300B-96F1-B4AF12B96488}"
+        Name = "Microsoft Visual C++ 2015 x64 Minimum Runtime - 14.0.23026"
         Arguments = "/install /passive /norestart"
     }
 
@@ -90,12 +99,12 @@ Configuration xPhpProvision
     }
 
     if ($InstallMySqlExt)
-    {               
+    {
         # Make sure the MySql extention for PHP is in the main PHP path
         File phpMySqlExt
         {
-            SourcePath = "$($DestinationPath)\ext\php_mysql.dll"
-            DestinationPath = "$($DestinationPath)\php_mysql.dll"
+            SourcePath = "$($DestinationPath)\ext\php_mysqli.dll"
+            DestinationPath = "$($DestinationPath)\php_mysqli.dll"
             Ensure = "Present"
             DependsOn = @("[Archive]PHP")
             MatchSource = $true

--- a/DscResources/xPhpProvision/xPhpProvision.psd1
+++ b/DscResources/xPhpProvision/xPhpProvision.psd1
@@ -46,7 +46,7 @@ Copyright = '(c) 2014 Microsoft. All rights reserved.'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @( 'xPsDesiredStateConfiguration', 'xWebAdministration' )
+# RequiredModules = @( 'xPsDesiredStateConfiguration', 'xWebAdministration' )
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()
@@ -91,4 +91,3 @@ AliasesToExport = '*'
 # DefaultCommandPrefix = ''
 
 }
-

--- a/README.md
+++ b/README.md
@@ -1,37 +1,44 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/4umfdsbj520bmely/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xphp/branch/master)
-
 # xPhp
 
+[![Build status](https://ci.appveyor.com/api/projects/status/4umfdsbj520bmely/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xphp/branch/master)
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+ or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
+ additional questions or comments.
 
 ## Contributing
-Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
 
+Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
 
 ## Resources
 
 ### xPhpProvision
 
-* **PackageFolder**: The folder to download the PHP and Visual C++ 2012 packages to. **Note:** this must already exist. 
+* **PackageFolder**: The folder to download the PHP and Visual C++ 2012 packages
+ to. **Note:** this must already exist.
 * **DownloadUri**: The URL/URI for the PHP package.
-* **VcRedistDownloadUri**: The URL/URI for the Visual Studio C++ 2012 Redistributiable package.
+* **VcRedistDownloadUri**: The URL/URI for the Visual Studio C++ 2012
+ Redistributiable package.
 * **DestinationPath**: The path to install PHP.
-* **ConfigurationPath**: The path to the file to use as PHP.ini. 
+* **ConfigurationPath**: The path to the file to use as PHP.ini.
 * **InstallMySqlExt**: A boolean indicating if the MySQL extension should be installed.
-
 
 ## Versions
 
 ### Unreleased
+
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
+* Changed xPhpProvison so that it loads, fixes #7.
+* Updated Sample to use PHP 7.1.4
+* Introduced integration test.
 
 ### 1.2.0.0
 
 * Added dependencies on xPSDesiredStateConfiguration and xWebAdministration
-* Renamed the resource as it was named against naming standards and resources cannot be named the same as the module. 
-    - xPhpProvision
+* Renamed the resource as it was named against naming standards and resources
+ cannot be named the same as the module.
+  * xPhpProvision
 
 ### 1.1.0.0
 
@@ -39,64 +46,66 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### 1.0.1
 
-* Initial release with the following resources 
-    - xPhp
+* Initial release with the following resources
+  * xPhp
 
 ## Examples
 
 ### Setup a PHP Server on a single node
 
 This configuration will setup a PHP server on a single node.
-Note: this configuration requires the following other modules: **xWebAdministration**, and **xPsDesiredStateConfiguration**. 
+Note: this configuration requires the following other modules:
+ **xWebAdministration**, and **xPsDesiredStateConfiguration**.
 
 ```powershell
-# This configuration will, via the xPhpProvision composite configuration: 
-# 1) Make sure IIS is installed 
-# 2) Make sure PHP is present 
-# 3) Make sure that PHP is registered with IIS 
-# 4) Make sure PHP is in the path 
-# 
-# ********* NOTE *********** 
-# PHP changes their download URLs frequently.  Please verify the URL. 
-# the VC Redist URL changes less frequently, but should still be verified. 
-# After verifying the download URLs for the products and update them appropriately. 
-# ************************** 
-$scriptRoot = Split-Path $MyInvocation.MyCommand.Path 
-$phpIniPath = (Join-Path $scriptRoot "phpConfigTemplate.txt") 
-if (-not (Test-Path $phpIniPath)) 
-{ 
-    $message = "Missing required file $phpIniPath" 
-    # This file is in the samples folder of the resource 
-    throw $message 
-} 
-Configuration SamplePhp 
-{ 
-    # Import composite resources 
-    Import-DscResource -module xPhp 
-    Node "localhost" 
-    { 
-        File PackagesFolder 
-        { 
-            DestinationPath = "C:\package" 
-            Type = "Directory" 
-            Ensure = "Present" 
-        } 
-        # Make sure PHP is installed in IIS 
-        xPhpProvision  php 
-        { 
-            InstallMySqlExt = $true 
-            PackageFolder =  "C:\package" 
-            # Update with the latest "VC11 x64 Non Thread Safe" from http://windows.php.net/download/ 
-            DownloadURI = "http://windows.php.net/downloads/releases/php-5.5.14-nts-Win32-VC11-x64.zip" 
-            DestinationPath = "C:\php" 
-            ConfigurationPath = $phpIniPath 
-            Vc2012RedistDownloadUri = "http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe" 
-            # Removed because this dependency does not work in Windows Server 2012 R2 and below 
-            # This should work in WMF v5 and above 
-            # DependsOn = "[IisPreReqs_WordPress]Iis" 
-        } 
-    } 
-} 
-SamplePhp 
+# This configuration will, via the xPhpProvision composite configuration:
+# 1) Make sure IIS is installed
+# 2) Make sure PHP is present
+# 3) Make sure that PHP is registered with IIS
+# 4) Make sure PHP is in the path
+#
+# ********* NOTE ***********
+# PHP changes their download URLs frequently.  Please verify the URL.
+# the VC Redist URL changes less frequently, but should still be verified.
+# After verifying the download URLs for the products and update them appropriately.
+# **************************
+$scriptRoot = Split-Path $MyInvocation.MyCommand.Path
+$phpIniPath = (Join-Path $scriptRoot "phpConfigTemplate.txt")
+if (-not (Test-Path $phpIniPath))
+{
+    $message = "Missing required file $phpIniPath"
+    # This file is in the samples folder of the resource
+    throw $message
+}
+Configuration SamplePhp
+{
+    # Import composite resources
+    Import-DscResource -module xPhp
+    Node "localhost"
+    {
+        File PackagesFolder
+        {
+            DestinationPath = "C:\package"
+            Type = "Directory"
+            Ensure = "Present"
+        }
+        # Make sure PHP is installed in IIS
+        xPhpProvision php
+        {
+            InstallMySqlExt = $true
+            PackageFolder =  "C:\package"
+            # Update with the latest "VC14 x64 Non Thread Safe" from http://windows.php.net/download/
+            DownloadURI = 'http://windows.php.net/downloads/releases/php-7.1.4-nts-Win32-VC14-x64.zip'
+            DestinationPath = 'C:\php'
+            ConfigurationPath = $phpIniPath
+            Vc2012RedistDownloadUri = 'https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe'
+            # Removed because this dependency does not work in
+            # Windows Server 2012 R2 and below
+            # This should work in WMF v5 and above
+            # DependsOn = "[IisPreReqs_WordPress]Iis"
+        }
+    }
+}
+SamplePhp
 Start-DscConfiguration -path .\SamplePhp -wait -verbose
 ```

--- a/Samples/InstallRequiredModules.ps1
+++ b/Samples/InstallRequiredModules.ps1
@@ -6,4 +6,3 @@ Write-Host "Installing required modules..."
 Install-Module xWebAdministration -MinimumVersion 1.3.2 -Force
 Install-Module xPSDesiredStateConfiguration -MinimumVersion 3.0.1 -Force
 Install-Module xPhp -MinimumVersion 1.0.1 -Force
-

--- a/Samples/UsingxPhpCompositeConfiguration.ps1
+++ b/Samples/UsingxPhpCompositeConfiguration.ps1
@@ -34,15 +34,15 @@ Configuration SamplePhp
         }
 
         # Make sure PHP is installed in IIS
-        xPhpProvision  php
+        xPhpProvision php
         {
             InstallMySqlExt = $true
             PackageFolder =  'C:\package'
-            # Update with the latest "VC11 x64 Non Thread Safe" from http://windows.php.net/download/
-            DownloadURI = 'http://windows.php.net/downloads/releases/php-5.6.8-nts-Win32-VC11-x64.zip'
+            # Update with the latest "VC14 x64 Non Thread Safe" from http://windows.php.net/download/
+            DownloadURI = 'http://windows.php.net/downloads/releases/php-7.1.4-nts-Win32-VC14-x64.zip'
             DestinationPath = 'C:\php'
             ConfigurationPath = $phpIniPath
-            Vc2012RedistDownloadUri = 'http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe'
+            Vc2012RedistDownloadUri = 'https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe'
 
             # Removed because this dependency does not work in Windows Server 2012 R2 and below
             # This should work in WMF v5 and above
@@ -53,4 +53,4 @@ Configuration SamplePhp
 
 SamplePhp
 
-Start-DscConfiguration -path .\SamplePhp -wait -verbose
+Start-DscConfiguration -Path .\SamplePhp -Wait -Verbose

--- a/Tests/Integration/xPhpProvision.Integration.tests.ps1
+++ b/Tests/Integration/xPhpProvision.Integration.tests.ps1
@@ -32,11 +32,9 @@ try
 
     $DSCConfig = Import-LocalizedData -BaseDirectory $PSScriptRoot -FileName "$($script:DSCResourceName).config.psd1"
 
-    Describe "$($script:DSCResourceName)_Integration"
-    {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
-        It 'Should compile and apply the MOF without throwing'
-        {
+        It 'Should compile and apply the MOF without throwing' {
             {
                 & "$($script:DSCResourceName)_Config" -ConfigurationData $DSCConfig -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive `
@@ -44,14 +42,12 @@ try
             } | Should not throw
         }
 
-        It 'Should be able to call Get-DscConfiguration without throwing'
-        {
+        It 'Should be able to call Get-DscConfiguration without throwing' {
             { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
         }
         #endregion
 
-        It 'Should have set the resource and all the parameters should match'
-        {
+        It 'Should have set the resource and all the parameters should match' {
             $currentConfiguration = Get-DscConfiguration
 
             # Visual C++ Runtime should be installed

--- a/Tests/Integration/xPhpProvision.Integration.tests.ps1
+++ b/Tests/Integration/xPhpProvision.Integration.tests.ps1
@@ -1,0 +1,102 @@
+$script:DSCModuleName      = 'xPhp'
+$script:DSCResourceName    = 'xPhpProvision'
+
+#region HEADER
+# Integration Test Template Version: 1.1.1
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
+
+#endregion
+
+$backupName = "$($script:DSCResourceName)_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+
+# Using try/finally to always cleanup.
+try
+{
+    #region Integration Tests
+
+    Backup-WebConfiguration -Name $backupName | Out-Null
+
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    . $configFile
+
+    $DSCConfig = Import-LocalizedData -BaseDirectory $PSScriptRoot -FileName "$($script:DSCResourceName).config.psd1"
+
+    Describe "$($script:DSCResourceName)_Integration"
+    {
+        #region DEFAULT TESTS
+        It 'Should compile and apply the MOF without throwing'
+        {
+            {
+                & "$($script:DSCResourceName)_Config" -ConfigurationData $DSCConfig -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive `
+                    -ComputerName localhost -Wait -Verbose -Force
+            } | Should not throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration without throwing'
+        {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+        }
+        #endregion
+
+        It 'Should have set the resource and all the parameters should match'
+        {
+            $currentConfiguration = Get-DscConfiguration
+
+            # Visual C++ Runtime should be installed
+            $vcredist = Get-WmiObject -Class Win32_Product | Where-Object { `
+                $_.IdentifyingNumber -eq '{0D3E9E15-DE7A-300B-96F1-B4AF12B96488}' }
+            $vcredist | Should Not BeNullOrEmpty
+
+            (Join-Path $DSCConfig.AllNodes.PackageFolder 'php.zip') | Should Exist
+
+            $DSCConfig.AllNodes.PhpInstallFolder | Should Exist
+            $phpFiles = Get-ChildItem -Path $DSCConfig.AllNodes.PhpInstallFolder
+            $phpFiles | Where-Object { $_.Name -eq 'php.exe' } | Should Not BeNullOrEmpty
+            $phpFiles | Where-Object { $_.Name -eq 'php_mysqli.dll' } | Should Not BeNullOrEmpty
+            $phpFiles | Where-Object { $_.Name -eq 'php.ini' } | Should Not BeNullOrEmpty
+            $phpFiles | Where-Object { $_.Name -eq 'php-cgi.exe' } | Should Not BeNullOrEmpty
+
+            $env:Path | Should Match ([regex]::Escape("$($DSCConfig.AllNodes.PhpInstallFolder)"))
+
+            $phpCgiPath = Join-Path $DSCConfig.AllNodes.PhpInstallFolder 'php-cgi.exe'
+            { Get-WebConfigurationProperty `
+                -PSPath 'MACHINE/WEBROOT/APPHOST' `
+                -Filter "system.webServer/fastCgi/application[@fullPath='$phpCgiPath']" `
+                -Name '.' `
+            } | Should Not BeNullOrEmpty
+
+            foreach ($feature in @("Web-Server", "Web-Mgmt-Tools", "Web-Default-Doc", `
+                    "Web-Dir-Browsing", "Web-Http-Errors", "Web-Static-Content", `
+                    "Web-Http-Logging", "Web-Stat-Compression", "Web-Filtering", `
+                    "Web-CGI", "Web-ISAPI-Ext", "Web-ISAPI-Filter"))
+            {
+                (Get-WindowsFeature -Name $feature).Installed | Should Be $True
+            }
+        }
+    }
+    #endregion
+
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    #endregion
+
+    Restore-WebConfiguration -Name $backupName
+    Remove-WebConfigurationBackup -Name $backupName
+}

--- a/Tests/Integration/xPhpProvision.config.ps1
+++ b/Tests/Integration/xPhpProvision.config.ps1
@@ -1,0 +1,26 @@
+<#
+.Synopsis
+   DSC Configuration testing if PHP can be provisioned using xPhpProvision
+#>
+Configuration xPhpProvision_Config {
+    Import-DscResource -ModuleName 'xPhp'
+
+    Node $AllNodes.NodeName {
+        File PackagesFolder
+        {
+            DestinationPath = $Node.PackageFolder
+            Type = 'Directory'
+            Ensure = 'Present'
+        }
+
+        xPhpProvision Php
+        {
+            InstallMySqlExt = $true
+            PackageFolder = $Node.PackageFolder
+            DownloadURI = $Node.PhpDownloadUri
+            DestinationPath = $Node.PhpInstallFolder
+            ConfigurationPath = (Join-Path $Node.PhpInstallFolder 'php.ini')
+            Vc2012RedistDownloadUri = $Node.VCDownloadUri
+        }
+    }
+}

--- a/Tests/Integration/xPhpProvision.config.psd1
+++ b/Tests/Integration/xPhpProvision.config.psd1
@@ -1,0 +1,11 @@
+@{
+    AllNodes = @(
+        @{
+            NodeName                    = 'localhost'
+            PackageFolder               = 'C:\package'
+            PhpDownloadUri              = 'http://windows.php.net/downloads/releases/php-7.1.4-nts-Win32-VC14-x64.zip'
+            VCDownloadUri               = 'https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe'
+            PhpInstallFolder            = 'C:\php'
+        }
+    )
+}

--- a/xPhp.psd1
+++ b/xPhp.psd1
@@ -29,7 +29,7 @@ Copyright = '(c) 2014 Microsoft Corporation. All rights reserved.'
 Description = 'Module for configuring PHP'
 
 # Minimum version of the Windows PowerShell engine required by this module
-# PowerShellVersion = ''
+PowerShellVersion = '4.0'
 
 # Name of the Windows PowerShell host required by this module
 # PowerShellHostName = ''
@@ -117,6 +117,3 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
-
-
-


### PR DESCRIPTION
- Removed RequiredModules from xPhpProvision. As this resulted in the xPhpProvision resource not loading. This fixes PowerShell/xPhp#7.
- Introduced integration test
- Cleanup code.
- Reformatted Readme.md
- Added MetaTestOptIn.json.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xphp/8)
<!-- Reviewable:end -->
